### PR TITLE
Changed trusty to xenial in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: C
-dist: trusty
+dist: xenial
 sudo: true
 
 env:


### PR DESCRIPTION
I changed trusty to xenial in travis.yml. It now builds Emacs 27.1 successfully.